### PR TITLE
Update Android dependencies to 2.18.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amazonaws:aws-android-sdk-mobile-client:2.16.12'
-    implementation 'com.amazonaws:aws-android-sdk-cognitoauth:2.16.12'
+    implementation 'com.amazonaws:aws-android-sdk-mobile-client:2.18.0'
+    implementation 'com.amazonaws:aws-android-sdk-cognitoauth:2.18.0'
 }


### PR DESCRIPTION
Hi!, I updated the android dependencies of `"com.amazonaws:aws-android-sdk-mobile-client"` and `"com.amazonaws:aws-android-sdk-cognitoauth"` from `2.16.12` to `2.18.0`
This to solve the performance problem when it is called "getTokens()".
https://github.com/aws-amplify/aws-sdk-android/issues/1722