### PR TITLE
Support for multi-environment configuration

### DIFF
--- a/android/src/main/kotlin/com/pycampers/flutter_cognito_plugin/Cognito.kt
+++ b/android/src/main/kotlin/com/pycampers/flutter_cognito_plugin/Cognito.kt
@@ -14,6 +14,7 @@ import com.amazonaws.mobile.client.results.SignInResult
 import com.amazonaws.mobile.client.results.SignUpResult
 import com.amazonaws.mobile.client.results.Tokens
 import com.amazonaws.mobile.client.results.UserCodeDeliveryDetails
+import com.amazonaws.mobile.config.AWSConfiguration
 import com.pycampers.plugin_scaffold.sendThrowable
 import com.pycampers.plugin_scaffold.trySend
 import io.flutter.plugin.common.MethodCall
@@ -24,7 +25,10 @@ class Cognito(val context: Context) {
     val awsClient = AWSMobileClient.getInstance()!!
 
     fun initialize(call: MethodCall, result: Result) {
-        awsClient.initialize(context, object : Callback<UserStateDetails> {
+        val configuration = call.argument<String>("configuration")
+        val awsConfig = AWSConfiguration(context)
+        if (configuration != null) awsConfig.configuration = configuration
+        awsClient.initialize(context, awsConfig, object : Callback<UserStateDetails> {
             override fun onResult(u: UserStateDetails) {
                 trySend(result) { dumpUserState(u) }
             }

--- a/ios/Classes/SwiftFlutterCognitoPlugin.swift
+++ b/ios/Classes/SwiftFlutterCognitoPlugin.swift
@@ -58,7 +58,7 @@ public class SwiftFlutterCognitoPlugin: NSObject, FlutterPlugin {
                 "showSignIn": plugin.showSignIn,
             ]
         )
-        plugin.awsClient.addUserStateListener("test" as NSString) { userState, _ in
+        plugin.userStateCallback = { userState, _ in
             channel.invokeMethod("userStateCallback", arguments: dumpUserState(userState))
         }
     }

--- a/lib/flutter_cognito_plugin.dart
+++ b/lib/flutter_cognito_plugin.dart
@@ -102,10 +102,10 @@ class Cognito {
   /// ```
   ///
   /// Returns the value of [Cognito.getCurrentUserState()].
-  static Future<UserState> initialize() async {
+  static Future<UserState> initialize({String configuration}) async {
     // don't trust the UserState returned by this
     // https://github.com/aws-amplify/aws-sdk-android/issues/873
-    await invokeMethod("initialize");
+    await invokeMethod("initialize", {"configuration": configuration});
 
     var userState = await Cognito.getCurrentUserState();
 


### PR DESCRIPTION
You can override the Default configuration by using the Cognito.initialize(configuration:) method.

```
{
    "AppSync": {
        "Default": {
            "ApiUrl": "YOUR-GRAPHQL-ENDPOINT",
            "Region": "us-east-1",
            "ApiKey": "YOUR-API-KEY",
            "AuthMode": "API_KEY"
        },
        "Custom": {
            "ApiUrl": "YOUR-GRAPHQL-ENDPOINT",
            "Region": "us-east-2",
            "ApiKey": "YOUR-API-KEY",
            "AuthMode": "API_KEY"
        }
   }
}
```

```
Cognito.initialize(configuration: 'Custom');
```